### PR TITLE
feat: prettier 설정 추가

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,6 +1,7 @@
 {
-  "extends": [
-    "next/core-web-vitals",
-    "plugin:storybook/recommended"
-  ]
+    "extends": [
+        "next/core-web-vitals",
+        "plugin:storybook/recommended",
+        "prettier"
+    ]
 }

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,9 @@
+{
+    "singleQuote": true,
+    "semi": true,
+    "tabWidth": 4,
+    "trailingComma": "all",
+    "printWidth": 100,
+    "endOfLine": "auto",
+    "jsxSingleQuote": true
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "@storybook/react": "^7.0.18",
         "@storybook/testing-library": "^0.0.14-next.2",
         "autoprefixer": "^10.4.14",
+        "eslint-config-prettier": "^8.8.0",
         "eslint-plugin-storybook": "^0.6.12",
         "jest": "^29.5.0",
         "postcss": "^8.4.24",
@@ -10512,6 +10513,18 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/eslint-config-prettier": {
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.8.0.tgz",
+      "integrity": "sha512-wLbQiFre3tdGgpDv67NQKnJuTlcUVYHas3k+DZCc2U2BadthoEY4B7hLPvAxaqdyOGCzuLfii2fqGph10va7oA==",
+      "dev": true,
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
       }
     },
     "node_modules/eslint-import-resolver-node": {
@@ -26762,6 +26775,13 @@
         "eslint-plugin-react": "^7.31.7",
         "eslint-plugin-react-hooks": "^4.5.0"
       }
+    },
+    "eslint-config-prettier": {
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.8.0.tgz",
+      "integrity": "sha512-wLbQiFre3tdGgpDv67NQKnJuTlcUVYHas3k+DZCc2U2BadthoEY4B7hLPvAxaqdyOGCzuLfii2fqGph10va7oA==",
+      "dev": true,
+      "requires": {}
     },
     "eslint-import-resolver-node": {
       "version": "0.3.7",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@storybook/react": "^7.0.18",
     "@storybook/testing-library": "^0.0.14-next.2",
     "autoprefixer": "^10.4.14",
+    "eslint-config-prettier": "^8.8.0",
     "eslint-plugin-storybook": "^0.6.12",
     "jest": "^29.5.0",
     "postcss": "^8.4.24",


### PR DESCRIPTION
1. 주요 설정 내용
	- singleQuote 사용
	- 줄바꿈 사용 길이 100으로 변경
	- tab 길이 4로 변경

2. eslint-config-prettier 설치
	- eslint와 prettier 설정 충돌시 eslint 설정을 무시하는 기능