### PR TITLE
feat: InputText 기능 추가, Label Atoms 구현

### DIFF
--- a/components/atoms/input-text/InputText.stories.tsx
+++ b/components/atoms/input-text/InputText.stories.tsx
@@ -22,3 +22,7 @@ export const smallInputText = () => {
 export const mediumInputText = () => {
     return <InputText size='medium' placeholder='medium'></InputText>;
 };
+
+export const largeInputText = () => {
+    return <InputText size='large' placeholder='large'></InputText>;
+};

--- a/components/atoms/input-text/InputText.tsx
+++ b/components/atoms/input-text/InputText.tsx
@@ -1,18 +1,19 @@
 export type InputProps = {
     placeholder: string;
-    size: 'small' | 'medium';
+    size: 'small' | 'medium' | 'large';
     maxlength: number;
-    name: 'host-name' | 'party-name' | 'place';
+    name: 'host-name' | 'party-name' | 'place' | 'party-detail' | 'gift-name' | 'gift-detail';
     onChange?: (e?: React.MouseEvent<HTMLInputElement>) => void;
 };
 
 const sizes = {
-    small: 'w-24 h-8',
-    medium: 'w-32 h-8',
+    small: 'w-24',
+    medium: 'w-40',
+    large: 'w-60',
 };
 
 const InputText = ({ size, placeholder, maxlength, name, onChange }: InputProps) => {
-    const style = 'outline-0 border-b-2 ' + sizes[size];
+    const style = 'outline-0 border-b-2 h-8 ' + sizes[size];
     return (
         <input
             name={name}

--- a/components/atoms/label/Label.stories.tsx
+++ b/components/atoms/label/Label.stories.tsx
@@ -1,0 +1,27 @@
+import Label from './Label';
+
+export default {
+    title: 'Label',
+    component: Label,
+    tags: ['autodocs'],
+};
+
+export const label = () => {
+    return <Label>Label</Label>;
+};
+
+label.story = {
+    name: 'Default',
+};
+
+export const smallLabel = () => {
+    return <Label size='small'>smallLabel</Label>;
+};
+
+export const mediumLabel = () => {
+    return <Label size='medium'>mediumLabel</Label>;
+};
+
+export const largeLabel = () => {
+    return <Label size='large'>largeLabel</Label>;
+};

--- a/components/atoms/label/Label.tsx
+++ b/components/atoms/label/Label.tsx
@@ -1,0 +1,20 @@
+export type LabelProps = {
+    children: React.ReactNode;
+    size: 'small' | 'medium' | 'large';
+};
+
+const sizes = {
+    small: 'text-sm',
+    medium: 'text-base',
+    large: 'text-lg',
+};
+
+const Label = ({ children, size }: LabelProps) => {
+    const style = '' + sizes[size];
+    return <p className={style}>{children}</p>;
+};
+
+Label.defaultProps = {
+    size: 'small',
+};
+export default Label;


### PR DESCRIPTION
### InputText 기능 추가
1. 사용처 확장
	- gift-name, gift-detail, party-detail이 추가됨
	- 원래 textarea 태그로 구현 예정이었으나, 여러 줄로 구현할 필요가 없어 input으로 통합하기로 함.

2. large 크기 추가, medium 크기 확장
	- 기존 2가지 size에 더해 large 크기를 추가
	- medium과 large의 구분을 위해 medium을 40으로 확장

### Label Atoms 구현
1. Label.tsx 구현 내용
	- children으로 내용 표현
	- props로 size를 받아 크기 표현

2. Label.stories.tsx 구현 내용
	- small, medium, large 3가지 size 미리보기