### PR TITLE
feat: Input-Host-Party-Container Organisms 구현

### DIFF
--- a/components/organisms/InputHostPartyContainer.tsx/InputHostPartyContainer.stories.tsx
+++ b/components/organisms/InputHostPartyContainer.tsx/InputHostPartyContainer.stories.tsx
@@ -1,0 +1,11 @@
+import InputHostPartyContainer from './InputHostPartyContainer';
+
+export default {
+    title: 'Design Systems/Organisms/Input-Host-Party-Container',
+    component: InputHostPartyContainer,
+    tags: ['autodocs'],
+};
+
+export const inputHostPartyContainer = () => {
+    return <InputHostPartyContainer></InputHostPartyContainer>;
+};

--- a/components/organisms/InputHostPartyContainer.tsx/InputHostPartyContainer.tsx
+++ b/components/organisms/InputHostPartyContainer.tsx/InputHostPartyContainer.tsx
@@ -1,0 +1,53 @@
+import LabelInputText from '@molecules/label-input-text/LabelInputText';
+
+export type InputHostPartyContainerProps = {
+    labelHost: string;
+    labelParty: string;
+    placeholderHost: string;
+    placeholderParty: string;
+    sizeHost: 'small' | 'medium';
+    sizeParty: 'small' | 'medium';
+    maxlengthHost: number;
+    maxlengthParty: number;
+};
+
+const InputHostPartyContainer = ({
+    labelHost,
+    labelParty,
+    placeholderHost,
+    placeholderParty,
+    maxlengthHost,
+    maxlengthParty,
+    sizeHost,
+    sizeParty,
+}: InputHostPartyContainerProps) => {
+    return (
+        <div className='flex flex-row items-center gap-10'>
+            <LabelInputText
+                lable={labelHost}
+                placeholder={placeholderHost}
+                maxlength={maxlengthHost}
+                size={sizeHost}
+            ></LabelInputText>
+            <LabelInputText
+                lable={labelParty}
+                placeholder={placeholderParty}
+                size={sizeParty}
+                maxlength={maxlengthParty}
+            ></LabelInputText>
+        </div>
+    );
+};
+
+InputHostPartyContainer.defaultProps = {
+    labelHost: '주인공 :',
+    labelParty: '일정 :',
+    placeholderHost: '이름',
+    placeholderParty: '생일',
+    sizeHost: 'small',
+    sizeParty: 'medium',
+    maxlengthHost: 10,
+    maxlengthParty: 20,
+};
+
+export default InputHostPartyContainer;


### PR DESCRIPTION
- LabelInputText Molecules 2개가 병렬로 연결되어 있는 구조
- 각 LabelInputText마다 따로 props를 전달하여 구현