### PR TITLE
feat: Label-Only, Lable-Input Molecules에 display 기능 추가

### DIFF
--- a/components/molecules/label-input/LabelInput.stories.tsx
+++ b/components/molecules/label-input/LabelInput.stories.tsx
@@ -69,3 +69,13 @@ export const lableInputTime = () => {
         </LabelInput>
     );
 };
+
+export const inputOnly = () => {
+    return (
+        <LabelInput>
+            <InputText size='medium' placeholder='이름'></InputText>
+            <InputText size='medium' placeholder='선물'></InputText>
+            <InputText size='large' placeholder='자세한 설명'></InputText>
+        </LabelInput>
+    );
+};

--- a/components/molecules/label-input/LabelInput.tsx
+++ b/components/molecules/label-input/LabelInput.tsx
@@ -1,9 +1,20 @@
 export type LabelInputProps = {
     children: React.ReactNode;
+    display: 'flex' | 'grid';
 };
 
-const LabelInput = ({ children }: LabelInputProps) => {
-    return <div className='flex flex-row items-center gap-2'>{children}</div>;
+const displays = {
+    flex: 'flex flex-row items-center gap-2',
+    grid: 'grid gap-4 pb-2 sm:w-[630px] sm:grid-cols-custom sm:gap-8',
+};
+
+const LabelInput = ({ children, display }: LabelInputProps) => {
+    const style = displays[display];
+    return <div className={style}>{children}</div>;
+};
+
+LabelInput.defaultProps = {
+    display: 'flex',
 };
 
 export default LabelInput;

--- a/components/molecules/labels-only/LabelsOnly.stories.tsx
+++ b/components/molecules/labels-only/LabelsOnly.stories.tsx
@@ -7,25 +7,25 @@ export default {
     tags: ['autodocs'],
 };
 
-export const labelsOnly = () => {
+export const labelsOnlyFlex = () => {
     return (
-        <LabelsOnly>
+        <LabelsOnly display='flex'>
             <Label>라벨</Label>
         </LabelsOnly>
     );
 };
 
-export const titleLabel = () => {
+export const titleLabelFlex = () => {
     return (
-        <LabelsOnly border='true'>
+        <LabelsOnly display='flex' border='true'>
             <Label size='large'>OO님의 기념일</Label>
         </LabelsOnly>
     );
 };
 
-export const timePlaceLabel = () => {
+export const timePlaceLabelFlex = () => {
     return (
-        <LabelsOnly border='false'>
+        <LabelsOnly display='flex' border='false'>
             <Label size='medium'>6월 27일</Label>
             <Label size='medium'>18시 00분</Label>
             <Label size='medium'>우리집</Label>
@@ -33,10 +33,20 @@ export const timePlaceLabel = () => {
     );
 };
 
-export const detailsLabel = () => {
+export const detailsLabelFlex = () => {
     return (
-        <LabelsOnly border='bottom'>
+        <LabelsOnly display='flex' border='bottom'>
             <Label size='medium'>자세한 설명이 들어갈 자리로, 최대 길이 50자</Label>
+        </LabelsOnly>
+    );
+};
+
+export const commentLabelGrid = () => {
+    return (
+        <LabelsOnly display='grid' border='bottom'>
+            <Label size='medium'>이름</Label>
+            <Label size='medium'>선물</Label>
+            <Label size='medium'>자세한 설명</Label>
         </LabelsOnly>
     );
 };

--- a/components/molecules/labels-only/LabelsOnly.tsx
+++ b/components/molecules/labels-only/LabelsOnly.tsx
@@ -1,6 +1,7 @@
 export type LabelsOnlyProps = {
     children: React.ReactNode;
     border: 'true' | 'false' | 'bottom';
+    display: 'flex' | 'grid';
 };
 
 const borders = {
@@ -9,13 +10,18 @@ const borders = {
     bottom: 'border-b',
 };
 
-const LabelsOnly = ({ children, border }: LabelsOnlyProps) => {
-    const style =
-        'flex flex-row flex-wrap justify-center p-2 gap-10 sm:w-[550px] sm:p-4 ' + borders[border];
+const displays = {
+    flex: 'flex flex-row flex-wrap justify-center p-2 gap-10 sm:w-[550px] sm:p-4 ',
+    grid: 'grid gap-4 pb-2 sm:w-[630px] sm:grid-cols-custom sm:gap-8 ',
+};
+
+const LabelsOnly = ({ children, border, display }: LabelsOnlyProps) => {
+    const style = displays[display] + borders[border];
     return <div className={style}>{children}</div>;
 };
 
 LabelsOnly.defaultProps = {
+    display: 'flex',
     border: 'true',
 };
 


### PR DESCRIPTION
- flex, gird 레이아웃을 가지는 display props 추가됨
- display: 'flex' | 'grid'