### PR TITLE
feat: Home-Template 구현 및 관련 css 작업

### DIFF
--- a/components/atoms/background/Background.tsx
+++ b/components/atoms/background/Background.tsx
@@ -7,7 +7,7 @@ const colors = {
 };
 
 const Background = ({ color }: BackgroundProp) => {
-    const style = ' w-full h-full absolute top-0 left-0 ' + colors[color];
+    const style = ' w-full h-full fixed top-0 left-0 z-[-1] ' + colors[color];
     return <section className={style}></section>;
 };
 

--- a/components/atoms/calendar/Calendar.tsx
+++ b/components/atoms/calendar/Calendar.tsx
@@ -5,9 +5,9 @@ import { DateCalendar } from '@mui/x-date-pickers/DateCalendar';
 
 const Calendar = () => {
     return (
-        <div className='h-80 overflow-hidden'>
+        <div className='m-auto box-border h-80 w-[280px] p-0 xs:w-[320px]'>
             <LocalizationProvider dateAdapter={AdapterDayjs}>
-                <DateCalendar className='h-80 overflow-hidden' />
+                <DateCalendar />
             </LocalizationProvider>
         </div>
     );

--- a/components/atoms/gridPaper/GridPaper.tsx
+++ b/components/atoms/gridPaper/GridPaper.tsx
@@ -10,27 +10,30 @@ box-sizing: border-box;
 width: 100%;
 height: 100%;
 overflow: overlay;
-@media (max-width: 375px) {
-  width: 320px;
-  height: 320px;
+@media (max-width: 340px) {
+  left: 0
+  width: 288px;
+  height: 288px;
   padding: 0;
   margin: 0;
 }
 top: 0;
 left: 0;
-margin: 0;
-background-color: #f6f6f6;
+margin: auto;
+background-color: #ffffff;
+justify-content: center;
 background-image:
-    linear-gradient(90deg, #cdcccc 0px, #cdcccc 1px, transparent 1px, transparent 99px,  transparent 100px),
-    linear-gradient(#cdcccc 0px, #cdcccc 1px, transparent 1px, transparent 99px,  transparent 100px),
-    linear-gradient(#e0e0e0 0px, #e0e0e0 1px, transparent 1px, transparent 99px,  transparent 100px),
-    linear-gradient(90deg, #e0e0e0 0px, #e0e0e0 1px, transparent 1px, transparent 99px,  transparent 100px),
-    linear-gradient(transparent 0px, transparent 5px, #f6f6f6 5px, #f6f6f6 95px, transparent 95px, transparent 100px),
-    linear-gradient(90deg, #e0e0e0 0px, #e0e0e0 1px, transparent 1px, transparent 99px, #e0e0e0 99px, #e0e0e0 100px),
-    linear-gradient(90deg, transparent 0px, transparent 5px, #f6f6f6 5px, #f6f6f6 95px, transparent 95px, transparent 100px),
-    linear-gradient(transparent 0px, transparent 1px, #f6f6f6 1px, #f6f6f6 99px, transparent 99px, transparent 100px),
-    linear-gradient(#cdcccc, #cdcccc);
+    linear-gradient(90deg, #EDEDED 0px, #EDEDED 1px, transparent 1px, transparent 99px,  transparent 100px),
+    linear-gradient(#EDEDED 0px, #EDEDED 1px, transparent 1px, transparent 99px,  transparent 100px),
+    linear-gradient(#EDEDED 0px, #EDEDED 1px, transparent 1px, transparent 99px,  transparent 100px),
+    linear-gradient(90deg, #e0e0e0 0px, #EDEDED 1px, transparent 1px, transparent 99px,  transparent 100px),
+    linear-gradient(transparent 0px, transparent 5px, #ffffff 5px, #ffffff 95px, transparent 95px, transparent 100px),
+    linear-gradient(90deg, #EDEDED 0px, #EDEDED 1px, transparent 1px, transparent 99px, #EDEDED 99px, #EDEDED 100px),
+    linear-gradient(90deg, transparent 0px, transparent 5px, #ffffff 5px, #ffffff 95px, transparent 95px, transparent 100px),
+    linear-gradient(transparent 0px, transparent 1px, #ffffff 1px, #ffffff 99px, transparent 99px, transparent 100px),
+    linear-gradient(#EDEDED, #EDEDED);
   background-size:100px 100%, 100% 100px, 100% 10px, 10px 100%, 100% 100px, 100px 100%, 100px 100%, 100px 100px, 100px 100px;
+  opcity: 0.5;
 `);
 
 const GridPaper = ({ children }: gridPaperProps) => {

--- a/components/atoms/headline/Headline.tsx
+++ b/components/atoms/headline/Headline.tsx
@@ -1,5 +1,5 @@
 const Headline = () => {
-    return <div className='w-80 border-b-2 border-dotted'></div>;
+    return <div className='m-auto mb-10 mt-12 w-52 border-b-2 border-dotted xs:w-64 sm:w-96'></div>;
 };
 
 export default Headline;

--- a/components/atoms/input-text/InputText.tsx
+++ b/components/atoms/input-text/InputText.tsx
@@ -12,7 +12,7 @@ const sizes = {
     small: 'w-24 ',
     medium: 'w-40 ',
     large: 'w-60 ',
-    extraLarge: 'w-96 ',
+    extraLarge: 'w-60 xs:w-88 sm:w-96 ',
 };
 
 const underlines = {

--- a/components/molecules/label-input/LabelInput.tsx
+++ b/components/molecules/label-input/LabelInput.tsx
@@ -7,7 +7,7 @@ export type LabelInputProps = {
 };
 
 const displays = {
-    flex: 'flex flex-row items-center gap-2 sm:w-[630px] ',
+    flex: 'flex flex-row items-center gap-2 w-fit m-auto ',
     grid: 'grid gap-4 pb-2 grid-cols-1 sm:w-[630px] sm:grid-cols-custom sm:gap-8 ',
 };
 

--- a/components/organisms/Label-Input-Container/LabelInputContainer.tsx
+++ b/components/organisms/Label-Input-Container/LabelInputContainer.tsx
@@ -1,6 +1,7 @@
 export type LabelInputContainerProps = {
     children: React.ReactNode;
     border: 'true' | 'false';
+    margin: 'false' | 'y';
 };
 
 const borders = {
@@ -8,14 +9,22 @@ const borders = {
     false: '',
 };
 
-const LabelInputContainer = ({ children, border }: LabelInputContainerProps) => {
+const margins = {
+    false: '',
+    y: 'my-4 ',
+};
+
+const LabelInputContainer = ({ children, border, margin }: LabelInputContainerProps) => {
     const style =
-        'flex flex-row flex-wrap justify-center gap-10 p-2 sm:w-[550px] sm:p-4 ' + borders[border];
+        'flex flex-row flex-wrap justify-center gap-3 p-1 w-fit m-auto sm:w-[630px] sm:p-4 ' +
+        borders[border] +
+        margins[margin];
     return <div className={style}>{children}</div>;
 };
 
 LabelInputContainer.defaultProps = {
     border: 'false',
+    margin: 'false',
 };
 
 export default LabelInputContainer;

--- a/components/organisms/Label-Input-Container/LabelInputContainer.tsx
+++ b/components/organisms/Label-Input-Container/LabelInputContainer.tsx
@@ -5,7 +5,7 @@ export type LabelInputContainerProps = {
 };
 
 const borders = {
-    true: 'rounded-xl border',
+    true: 'rounded-xl border ',
     false: '',
 };
 

--- a/components/organisms/grid-container/GridContainer.tsx
+++ b/components/organisms/grid-container/GridContainer.tsx
@@ -9,8 +9,10 @@ const sizes = {
 };
 
 const GridContainer = ({ children, size }: GridContainerProps) => {
-    const style = 'w-[320px] sm:w-[550px] overflow-scroll ' + sizes[size];
-    return <div className={style}>{children}</div>;
+    const style =
+        'box-border xs:w-fit sm:w-[550px] overflow-scroll justify-center m-auto mt-4 ' +
+        sizes[size];
+    return <article className={style}>{children}</article>;
 };
 
 GridContainer.defaultProps = {

--- a/components/templates/HomeTemplate.stories.tsx
+++ b/components/templates/HomeTemplate.stories.tsx
@@ -1,0 +1,65 @@
+import Background from '@atoms/background/Background';
+import HomeTemplate from './HomeTemplate';
+import Headline from '@atoms/headline/Headline';
+import Label from '@atoms/label/Label';
+import LabelInput from '@molecules/label-input/LabelInput';
+import LabelInputContainer from '@organisms/label-input-container/LabelInputContainer';
+import InputText from '@atoms/input-text/InputText';
+import GridContainer from '@organisms/grid-container/GridContainer';
+import GridPaper from '@atoms/gridPaper/GridPaper';
+import Calendar from '@atoms/calendar/Calendar';
+import InputTime from '@atoms/input-time/InputTime';
+import Button from '@atoms/button/Button';
+
+export default {
+    title: 'Design Systems/Templates/Home-Template',
+    component: HomeTemplate,
+    tags: ['autodocs'],
+};
+
+export const homeTemplate = () => {
+    return (
+        <HomeTemplate>
+            <Background></Background>
+            <Headline></Headline>
+            <LabelInputContainer border='true'>
+                <LabelInput>
+                    <Label>주인공</Label>
+                    <InputText placeholder='이름' size='medium' maxlength={25}></InputText>
+                </LabelInput>
+                <LabelInput>
+                    <Label>일정</Label>
+                    <InputText placeholder='생일' size='medium' maxlength={25}></InputText>
+                </LabelInput>
+            </LabelInputContainer>
+            <GridContainer>
+                <GridPaper>
+                    <Calendar></Calendar>
+                </GridPaper>
+            </GridContainer>
+            <LabelInputContainer border='false'>
+                <LabelInput>
+                    <Label>시간</Label>
+                    <InputTime></InputTime>
+                </LabelInput>
+                <LabelInput>
+                    <Label>장소</Label>
+                    <InputText placeholder='우리집' size='medium' maxlength={25}></InputText>
+                </LabelInput>
+            </LabelInputContainer>
+            <LabelInputContainer border='false' margin='y'>
+                <LabelInput>
+                    <InputText
+                        placeholder='자세한 설명을 추가해 보세요!'
+                        size='extraLarge'
+                        maxlength={50}
+                    ></InputText>
+                </LabelInput>
+            </LabelInputContainer>
+            <LabelInputContainer>
+                <Button>링크 복사</Button>
+                <Button>카카오톡 공유</Button>
+            </LabelInputContainer>
+        </HomeTemplate>
+    );
+};

--- a/components/templates/HomeTemplate.tsx
+++ b/components/templates/HomeTemplate.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+export type HomeTemplateProps = {
+    children: React.ReactNode;
+};
+
+const HomeTemplate = ({ children }: HomeTemplateProps) => {
+    return <section className='overflow-overlay justify-center'>{children}</section>;
+};
+
+export default HomeTemplate;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,18 +1,19 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
   content: [
-    './src/pages/**/*.{js,ts,jsx,tsx,mdx}',
-    './src/components/**/*.{js,ts,jsx,tsx,mdx}',
-    './src/app/**/*.{js,ts,jsx,tsx,mdx}',
+    './components/**/*.{tsx,mdx}',
+    './app/**/*.{tsx,mdx}',
   ],
   theme: {
+
     extend: {
-      backgroundImage: {
-        'gradient-radial': 'radial-gradient(var(--tw-gradient-stops))',
-        'gradient-conic':
-          'conic-gradient(from 180deg at 50% 50%, var(--tw-gradient-stops))',
-      },
+      gridTemplateColumns: {
+        'custom': '8rem 8rem 10rem',
     },
+    screens: {
+      'xs': '340px'
+    }
   },
   plugins: [],
+}
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,12 +19,13 @@
                 "name": "next"
             }
         ],
-        "baseUrl": ".",
+        "baseUrl": "./",
         "paths": {
             "@/*": ["./app/*"],
             "@atoms/*": ["./components/atoms/*"],
             "@molecules/*": ["./components/molecules/*"],
-            "@organisms/*": ["./components/organisms/*"]
+            "@organisms/*": ["./components/organisms/*"],
+            "@templates/*": ["./components/templates/*"]
         }
     },
     "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],


### PR DESCRIPTION
### 1. Home-Template 구현
- home 페이지를 구현할 템플릿 컴포넌트
- small mobile(320px), large moblie(414px), table(834px), 그 외 큰 사이즈 반응형 디자인 적용
- template 컴포넌트들에 대한 절대경로 지정 (@template/*)

### 2. 관련 CSS 작업
- 반응형 디자인 관련 css 값 수정
- 작은 모바일용 커스텀 media query, 커스텀 grid 추가
- tailwind CSS 띄어쓰기 오류 수정

